### PR TITLE
Rename LogicalExpression to ShortCircuitExpression

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -24,7 +24,7 @@ contributors: Daniel Ehrenberg, Daniel Rosenwasser
   <h2>Syntax</h2>
   <emu-grammar type="definition">
     <ins>
-    LogicalExpression[In, Yield, Await] :
+    ShortCircuitExpression[In, Yield, Await] :
       LogicalORExpression[?In, ?Yield, ?Await]
       CoalesceExpression[?In, ?Yield, ?Await]
 
@@ -92,8 +92,8 @@ contributors: Daniel Ehrenberg, Daniel Rosenwasser
         LogicalORExpression[?In, ?Yield, ?Await] `?` AssignmentExpression[+In, ?Yield, ?Await] `:` AssignmentExpression[?In, ?Yield, ?Await]
         </del>
         <ins>
-        LogicalExpression[?In, ?Yield, ?Await]
-        LogicalExpression[?In, ?Yield, ?Await] `?` AssignmentExpression[+In, ?Yield, ?Await] `:` AssignmentExpression[+In, ?Yield, ?Await]
+        ShortCircuitExpression[?In, ?Yield, ?Await]
+        ShortCircuitExpression[?In, ?Yield, ?Await] `?` AssignmentExpression[+In, ?Yield, ?Await] `:` AssignmentExpression[+In, ?Yield, ?Await]
         </ins>
   </emu-grammar>
 
@@ -102,7 +102,7 @@ contributors: Daniel Ehrenberg, Daniel Rosenwasser
     <emu-see-also-para op="IsFunctionDefinition"></emu-see-also-para>
     <emu-grammar>
       <del>ConditionalExpression : LogicalORExpression `?` AssignmentExpression `:` AssignmentExpression</del>
-      <ins>ConditionalExpression : LogicalExpression `?` AssignmentExpression `:` AssignmentExpression</ins>
+      <ins>ConditionalExpression : ShortCircuitExpression `?` AssignmentExpression `:` AssignmentExpression</ins>
     </emu-grammar>
     <emu-alg>
       1. Return *false*.
@@ -114,7 +114,7 @@ contributors: Daniel Ehrenberg, Daniel Rosenwasser
     <emu-see-also-para op="IsSimpleAssignmentTarget"></emu-see-also-para>
     <emu-grammar>
       <del>ConditionalExpression : LogicalORExpression `?` AssignmentExpression `:` AssignmentExpression</del>
-      <ins>ConditionalExpression : LogicalExpression `?` AssignmentExpression `:` AssignmentExpression</ins>
+      <ins>ConditionalExpression : ShortCircuitExpression `?` AssignmentExpression `:` AssignmentExpression</ins>
     </emu-grammar>
     <emu-alg>
       1. Return *false*.
@@ -125,11 +125,11 @@ contributors: Daniel Ehrenberg, Daniel Rosenwasser
     <h1>Runtime Semantics: Evaluation</h1>
     <emu-grammar>
       <del>ConditionalExpression : LogicalORExpression `?` AssignmentExpression `:` AssignmentExpression</del>
-      <ins>ConditionalExpression : LogicalExpression `?` AssignmentExpression `:` AssignmentExpression</ins>
+      <ins>ConditionalExpression : ShortCircuitExpression `?` AssignmentExpression `:` AssignmentExpression</ins>
     </emu-grammar>
     <emu-alg>
       1. <del>Let _lref_ be the result of evaluating |LogicalORExpression|.</del>
-      1. <ins>Let _lref_ be the result of evaluating |LogicalExpression|.</ins>
+      1. <ins>Let _lref_ be the result of evaluating |ShortCircuitExpression|.</ins>
       1. Let _lval_ be ToBoolean(? GetValue(_lref_)).
       1. If _lval_ is *true*, then
         1. Let _trueRef_ be the result of evaluating the first |AssignmentExpression|.
@@ -152,7 +152,7 @@ contributors: Daniel Ehrenberg, Daniel Rosenwasser
       <h1>Expression Rules</h1>
       <emu-grammar>
         <del>ConditionalExpression : LogicalORExpression `?` AssignmentExpression `:` AssignmentExpression</del>
-        <ins>ConditionalExpression : LogicalExpression `?` AssignmentExpression `:` AssignmentExpression</ins>
+        <ins>ConditionalExpression : ShortCircuitExpression `?` AssignmentExpression `:` AssignmentExpression</ins>
       </emu-grammar>
       <emu-alg>
         1. Let _has_ be HasCallInTailPosition of the first |AssignmentExpression| with argument _call_.


### PR DESCRIPTION
A nitpick to be sure, but we do want to set a good example for the community at large. :smile:

The word "logical" means "truth(iness)-oriented", so (unless we mean [ternary logic](https://en.wikipedia.org/wiki/Three-valued_logic) now 😛) I think it's important not to bucket our nullish-oriented `??` with `||`, `&&`, and `!` in this way. The thing that `??` truly has in common with `||` and `&&` is short-circuiting, so it's probably best to say just that.