### PR TITLE
Remove Lower Precedence condition

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -12,7 +12,6 @@ contributors: Daniel Ehrenberg, Daniel Rosenwasser
   <p>The main design decisions made in this specification are:
     <ol>
       <li>The right argument of `??` is evaluated only if needed ("short circuiting").</li>
-      <li>`??` has lower precedence than `||`.</li>
       <li>`??` cannot immediately contain, or be contained within, an `&amp;&amp;` or `||` operation.</li>
       <li>The right argument is selected if the left argument is `null` or `undefined`.</li>
     </ol>


### PR DESCRIPTION
It looks like the lower precedence was added by accident in https://github.com/tc39/proposal-nullish-coalescing/commit/ad8c179c79952d2b625ba81d7306dd45709d2997? As the spec text seems to disallow mixing, and lower precedence doesn't make sense if mixing is disallowed.