### PR TITLE
Correct spelling of title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Nullish Coalescing for JavaScript
+# Nullish Condescending for JavaScript
 
 ## Status
 Current Stage:


### PR DESCRIPTION
Correct spelling of title. Note this screenshot from VSCode showing that the operator is condescending (expected) rather than coalescing (incorrect description).

![nullish-condescending](https://user-images.githubusercontent.com/4691093/64773026-91fb3880-d549-11e9-8d28-6d10e5896d7a.png)

